### PR TITLE
[webgl] Fix CSS so background doesn't break to pieces

### DIFF
--- a/webgl/index.html
+++ b/webgl/index.html
@@ -1,22 +1,24 @@
 <!--
 Copyright (c) 2014 Intel Corporation. All rights reserved.
 Use of this source code is governed by a MIT-style license that can be
-found in the LICENSE file. 
+found in the LICENSE file.
 -->
 
 <html>
     <meta name="viewport" content="width=device-width">
     <head>
         <title>WebGL Crosswalk Sample</title>
-        <link rel='stylesheet' href='main.css'>
+        <link rel="stylesheet" href="main.css">
         <script src="threejs/three.min.js"></script>
         <script src="main.js"></script>
     </head>
     <body>
-        <div class='background tile-overlay'></div>
-        <div class='background' id='big-circle'></div>
-        <div class='background' id='small-circle'></div>
-        <div class='background' id='sunburst'></div>
-        <div id='logo'></div>
+        <div class="background tile-overlay"></div>
+        <div class="background" id="big-circle"></div>
+        <div class="background" id="small-circle"></div>
+        <div class="background" id="sunburst"></div>
+        <div class="logo">
+          <img src="textures/crosswalk-LOGO-lrg.png">
+        </div>
     </body>
 </html>

--- a/webgl/main.css
+++ b/webgl/main.css
@@ -1,31 +1,30 @@
 /*
 Copyright (c) 2014 Intel Corporation. All rights reserved.
 Use of this source code is governed by a MIT-style license that can be
-found in the LICENSE file. 
+found in the LICENSE file.
 */
 body {
     margin: 0px;
     overflow: hidden;
     background: -webkit-linear-gradient(bottom, #e76840 0%, #f49541 65%, #ed7332 100%);
-    background: linear-gradient(to top, #e76840 0%, #f49541 65%, #ed7332 100%); 
-    min-width: 408px;
+    background: linear-gradient(to top, #e76840 0%, #f49541 65%, #ed7332 100%);
 }
 
 #sunburst.background {
     background: -webkit-radial-gradient(50% 115%,  circle, white 0%, white 9%, rgba(252, 217, 89, 0.8) 17%, rgba(246, 137, 55, 0) 45%);
-    background: radial-gradient(  circle at 50% 115%, white 0%, white 9%, rgba(252, 217, 89, 0.8) 17%, rgba(246, 137, 55, 0) 45%); 
+    background: radial-gradient(  circle at 50% 115%, white 0%, white 9%, rgba(252, 217, 89, 0.8) 17%, rgba(246, 137, 55, 0) 45%);
 }
 
 #small-circle.background {
     background: -webkit-radial-gradient(50% 115%,  circle, rgba(250, 196, 72, 0.12) 0%, rgba(250, 196, 72, 0.12) 40%, transparent 40%);
-    background: radial-gradient(  circle at 50% 115%, rgba(250, 196, 72, 0.12) 0%, rgba(250, 196, 72, 0.12) 40%, transparent 40%); 
+    background: radial-gradient(  circle at 50% 115%, rgba(250, 196, 72, 0.12) 0%, rgba(250, 196, 72, 0.12) 40%, transparent 40%);
 }
 
 #big-circle.background {
     background: -webkit-radial-gradient(40% 115%,  farthest-side circle, rgba(222, 97, 62, 0.2) 0%, rgba(222, 97, 62, 0.3) 90%, transparent 90%);
-    background: radial-gradient( farthest-side circle at 40% 115%, rgba(222, 97, 62, 0.2) 0%, rgba(222, 97, 62, 0.3) 90%, transparent 90%); 
+    background: radial-gradient( farthest-side circle at 40% 115%, rgba(222, 97, 62, 0.2) 0%, rgba(222, 97, 62, 0.3) 90%, transparent 90%);
 }
- 
+
 .tile-overlay {
   background: url(textures/bg-tile.png);
 }
@@ -37,7 +36,7 @@ body {
     top: 0px;
     left: 0px;
     opacity: 1;
-    text-align: center; 
+    text-align: center;
 }
 
 canvas {
@@ -45,23 +44,24 @@ canvas {
     position: relative;
 }
 
-#logo {
+.logo {
     position: fixed;
     bottom: 0%;
-    padding-top: 5em;
-    display: inline-block;
-    background-image: url(textures/crosswalk-LOGO-lrg.png);
-    background-repeat: no-repeat;
-    background-position: 50% 100%;
-    background-size: 477px auto;
-    height: 51px;
+    margin-bottom: 70px;
     width: 100%;
-    margin-bottom: 36px; 
+    text-align: center;
+    z-index: 100;
+}
+
+.logo img {
+  width: 75%;
+  height: auto;
+  max-width: 477px;
 }
 
 @media (max-width: 520px) {
     #logo {
         background-size: 400px auto;
-        height: 42.7673 px; 
+        height: 42.7673 px;
     }
 }


### PR DESCRIPTION
Fixes to prevent the WebGL demo showing a white bar along the bottom of the screen and broken background images:
- Use a container for the logo
- Make the logo an img rather than a background
- Remove min-width on background (which causes breakage on smaller
  screens)
