### PR TITLE
Fixed the noise issue when using webrtc demo

### DIFF
--- a/webrtc/client/index.html
+++ b/webrtc/client/index.html
@@ -43,7 +43,7 @@
       <hr>
 
       <p><strong>LOCAL:</strong></p>
-      <video id="local-video" autoplay></video>
+      <video id="local-video" autoplay muted></video>
     </div>
 
     <hr>


### PR DESCRIPTION
The old implementation had loud noise due to playing the local voice
from microphone which will result in echo in loop. It is incorrect
usage. This PR will mute the voice in local video.