### PR TITLE
Update manifests for latest Crosswalk Project

### DIFF
--- a/hello_world/manifest.json
+++ b/hello_world/manifest.json
@@ -1,5 +1,5 @@
 {
   "name": "HelloWorld",
-  "xwalk_version": "0.0.0.1",
+  "xwalk_version": "0.0.1",
   "start_url": "index.html"
 }

--- a/simd-mandelbrot/manifest.json
+++ b/simd-mandelbrot/manifest.json
@@ -1,5 +1,5 @@
 {
   "name": "SIMD",
-  "xwalk_version": "0.0.0.1",
+  "xwalk_version": "0.0.1",
   "start_url": "index.html"
 }

--- a/space-dodge-game/Crosswalk-6-resize/manifest.json
+++ b/space-dodge-game/Crosswalk-6-resize/manifest.json
@@ -1,5 +1,5 @@
 {
   "name": "space_dodge_game",
-  "xwalk_version": "0.0.0.1",
+  "xwalk_version": "0.0.1",
   "start_url": "index.html"
 }

--- a/space-dodge-game/Crosswalk-6-scale/manifest.json
+++ b/space-dodge-game/Crosswalk-6-scale/manifest.json
@@ -1,5 +1,5 @@
 {
   "name": "space_dodge_game",
-  "xwalk_version": "0.0.0.1",
+  "xwalk_version": "0.0.1",
   "start_url": "index.html"
 }

--- a/space-dodge-game/Crosswalk-8-resize/manifest.json
+++ b/space-dodge-game/Crosswalk-8-resize/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "space_dodge_game",
-  "xwalk_version": "0.0.0.1",
+  "xwalk_version": "0.0.1",
   "start_url": "index.html",
   "orientation": "landscape",
   "display": "fullscreen",

--- a/space-dodge-game/Crosswalk-8-scale/manifest.json
+++ b/space-dodge-game/Crosswalk-8-scale/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "space_dodge_game",
-  "xwalk_version": "0.0.0.1",
+  "xwalk_version": "0.0.1",
   "start_url": "index.html",
   "orientation": "landscape",
   "display": "fullscreen",

--- a/space-dodge-game/master/manifest.json
+++ b/space-dodge-game/master/manifest.json
@@ -1,9 +1,5 @@
 {
   "name": "space_dodge_game",
-  "version": "0.0.0.1",
-  "app": {
-    "launch": {
-      "local_path": "index.html"
-    }
-  }
+  "xwalk_version": "0.0.1",
+  "start_url": "index.html"
 }

--- a/tizen_apis/manifest.json
+++ b/tizen_apis/manifest.json
@@ -1,10 +1,5 @@
 {
   "name": "System Information",
-  "manifest_version": 1,
-  "version": "0.0.0.1",
-  "app": {
-    "launch":{
-      "local_path": "index.html"
-    }
-  }
+  "version": "0.0.1",
+  "start_url": "index.html"
 }

--- a/webgl/manifest.json
+++ b/webgl/manifest.json
@@ -1,5 +1,5 @@
 {
   "name": "WebGLSample",
-  "xwalk_version": "0.0.0.1",
+  "xwalk_version": "0.0.1",
   "start_url": "index.html"
 }


### PR DESCRIPTION
Valid version numbers must follow the format "ab.cd.efg", where only 'a'
is mandatory.

As per `manifest-fields.json` in crosswalk-website, the manifest fields
`app.launch.local_path` and `version` have been replaced by `start_url`
and `xwalk-version` respectively since Crosswalk 8.

The samples shall not target a specific version of Crosswalk, instead
they shall target the latest ones. I will try to refine the space dodge
game samples for this purpose if no others take action at XWALK-4748.

BUG=https://crosswalk-project.org/jira/browse/XWALK-2569