### PR TITLE
Use extractLane function instead of SIMD.XXXX.x/y/z/w

### DIFF
--- a/simd-mandelbrot/mandelbrot-worker.js
+++ b/simd-mandelbrot/mandelbrot-worker.js
@@ -111,10 +111,10 @@ function drawMandelbrot (params) {
         var xf4 = SIMD.Float32x4(xf, xf, xf, xf);
         var yf4 = SIMD.Float32x4(yf, yf+yd, yf+yd+yd, yf+yd+yd+yd);
         var m4   = mandelx4 (xf4, yf4);
-        mapColorAndSetPixel (x, y,   m4.x);
-        mapColorAndSetPixel (x, y+1, m4.y);
-        mapColorAndSetPixel (x, y+2, m4.z);
-        mapColorAndSetPixel (x, y+3, m4.w);
+        mapColorAndSetPixel (x, y,   SIMD.Int32x4.extractLane(m4, 0));
+        mapColorAndSetPixel (x, y+1, SIMD.Int32x4.extractLane(m4, 1));
+        mapColorAndSetPixel (x, y+2, SIMD.Int32x4.extractLane(m4, 2));
+        mapColorAndSetPixel (x, y+3, SIMD.Int32x4.extractLane(m4, 3));
         yf += ydx4;
       }
     }


### PR DESCRIPTION
Crosswalk have added extractLane and replaceLane for SIMD.Float32x4, SIMD.Int32x4
(crosswalk-project/v8-crosswalk#118)

m.x/y/z/w -> SIMD.XXXX.extractLane(m, 0/1/2/3)
m.withX/Y/Z/W -> SIMD.XXXX.replaceLane(m, 0/1/2/3, value)

BUG=https://crosswalk-project.org/jira/browse/XWALK-5731