### PR TITLE
[webrtc] Add camera permisson in manifest.json for app tools

### DIFF
--- a/webrtc/client/manifest.json
+++ b/webrtc/client/manifest.json
@@ -2,5 +2,9 @@
   "name": "WebRTC",
   "xwalk_app_version": "0.0.1",
   "start_url": "index.html",
-  "xwalk_package_id": "org.xwalk.webrtc"
+  "xwalk_package_id": "org.xwalk.webrtc",
+  "xwalk_android_permissions": [
+    "CAMERA",
+    "RECORD_AUDIO"
+  ]
 }

--- a/webrtc/client/peer.js
+++ b/webrtc/client/peer.js
@@ -1151,7 +1151,7 @@ var util = {
 
     var pc, dc;
     try {
-      pc = new RTCPeerConnection(defaultConfig, {optional: [{RtpDataChannels: true}]});
+      pc = new RTCPeerConnection(defaultConfig);
     } catch (e) {
       data = false;
       audioVideo = false;
@@ -1176,7 +1176,7 @@ var util = {
       // Reliable test.
       // Unfortunately Chrome is a bit unreliable about whether or not they
       // support reliable.
-      var reliablePC = new RTCPeerConnection(defaultConfig, {});
+      var reliablePC = new RTCPeerConnection(defaultConfig);
       try {
         var reliableDC = reliablePC.createDataChannel('_PEERJSRELIABLETEST', {});
         sctp = reliableDC.reliable;
@@ -1194,7 +1194,7 @@ var util = {
     // av-only browsers (?).
     if (!onnegotiationneeded && data) {
       // sync default check.
-      var negotiationPC = new RTCPeerConnection(defaultConfig, {optional: [{RtpDataChannels: true}]});
+      var negotiationPC = new RTCPeerConnection(defaultConfig);
       negotiationPC.onnegotiationneeded = function() {
         onnegotiationneeded = true;
         // async check.


### PR DESCRIPTION
- Add CAMERA, DEVICE_POWER to xwalk_android_permission,
  the default permission will not contain them in app tools.

- http://www.w3.org/TR/webrtc/#interface-definition
  Update RTCPeerConnection constructor following latest spec.

BUG=https://crosswalk-project.org/jira/browse/XWALK-5960