### PR TITLE
Update android external extensions layout

### DIFF
--- a/extensions-android/README.md
+++ b/extensions-android/README.md
@@ -33,9 +33,9 @@ Android.
 Pre-condition:
 
   Update crosswalk version in `xwalk-echo-extension-src/build.xml` before run `build.sh`.<br />
-  e.g. change stable 8.37.189.14 to canary 15.44.375.0
+  e.g. change stable 15.44.384.13 to canary 18.46.452.0
 
-0. change `<property name="crosswalk-version" value="8.37.189.14" />` to `<property name="crosswalk-version" value="15.44.375.0" />`
+0. change `<property name="crosswalk-version" value="15.44.384.13" />` to `<property name="crosswalk-version" value="18.46.452.0" />`
 0. change `<get src="https://download.01.org/crosswalk/releases/crosswalk/android/stable/${crosswalk-version}/crosswalk-${crosswalk-version}.zip" dest="${crosswalk-zip}" />`
    to `<get src="https://download.01.org/crosswalk/releases/crosswalk/android/canary/${crosswalk-version}/crosswalk-${crosswalk-version}.zip" dest="${crosswalk-zip}" />`
 
@@ -46,7 +46,7 @@ executable, e.g. on Linux:
 
 Then run it with:
 
-    ./build.sh
+    ./build.sh -v <version> -a <arch> -m <mode>
 
 The locations of the output apk files are displayed when the script
 finishes.

--- a/extensions-android/xwalk-echo-app/manifest.json
+++ b/extensions-android/xwalk-echo-app/manifest.json
@@ -3,7 +3,7 @@
   "xwalk_app_version": "0.0.1",
   "start_url": "index.html",
   "xwalk_package_id": "org.crosswalkproject.sample",
-  "xwalk_extensions": ["../xwalk-echo-extension-src/xwalk-echo-extension"],
+  "xwalk_extensions": ["xwalk-echo-extension"],
   "icons": [
     {
       "src": "icon.png",

--- a/extensions-android/xwalk-echo-extension-src/build.xml
+++ b/extensions-android/xwalk-echo-extension-src/build.xml
@@ -7,7 +7,7 @@
   <property name="lib" value="lib" />
 
   <!-- Crosswalk Android version -->
-  <property name="crosswalk-version" value="8.37.189.14" />
+  <property name="crosswalk-version" value="15.44.384.13" />
 
   <!-- location of downloaded Crosswalk Android file -->
   <property name="crosswalk-zip" value="${lib}/crosswalk.zip" />
@@ -58,14 +58,14 @@
 
   <!-- compile the extension Java code -->
   <target name="compile" depends="download-deps, download-crosswalk">
-    <first id="app_runtime_java">
-      <fileset dir="${lib}/crosswalk-${crosswalk-version}" includes="**/xwalk_app_runtime_java.jar" />
+    <first id="xwalk_core_library_java">
+      <fileset dir="${lib}/crosswalk-${crosswalk-version}" includes="**/xwalk_core_library_java_app_part.jar" />
     </first>
     <javac srcdir="${src}" destdir="${build}"
            encoding="utf-8" debug="true" verbose="true">
       <classpath>
         <fileset dir="${lib}" includes="*.jar" />
-        <file file="${toString:app_runtime_java}" />
+        <file file="${toString:xwalk_core_library_java}" />
       </classpath>
     </javac>
   </target>

--- a/extensions-android/xwalk-echo-extension-src/java/org/crosswalkproject/sample/Echo.java
+++ b/extensions-android/xwalk-echo-extension-src/java/org/crosswalkproject/sample/Echo.java
@@ -3,11 +3,11 @@
  * found in the LICENSE-APACHE-V2 file. */
 package org.crosswalkproject.sample;
 
-import org.xwalk.app.runtime.extension.XWalkExtensionClient;
-import org.xwalk.app.runtime.extension.XWalkExtensionContextClient;
+import org.xwalk.core.extension.XWalkExternalExtension;
+import org.xwalk.core.extension.XWalkExtensionContextClient;
 import com.google.gson.Gson;
 
-public class Echo extends XWalkExtensionClient {
+public class Echo extends XWalkExternalExtension {
   private Gson gson = new Gson();
 
   public Echo(String name, String jsApiContent, XWalkExtensionContextClient xwalkContext) {


### PR DESCRIPTION
XWALK-5746 Move external extensions management framework down into Crosswalk Webview.

- Enhance build.sh to support crosswalk versions
- Put external extension into app source folder
- Migrate external extensions creation framework from xwalk_app_runtime
  layer to xwalk_core_library