### PR TITLE
[webrtc] Add permission for WebRTC audio channel

### DIFF
--- a/webrtc/client/manifest.json
+++ b/webrtc/client/manifest.json
@@ -5,6 +5,7 @@
   "xwalk_package_id": "org.xwalk.webrtc",
   "xwalk_android_permissions": [
     "CAMERA",
+    "MODIFY_AUDIO_SETTINGS",
     "RECORD_AUDIO"
   ]
 }


### PR DESCRIPTION
Permission MODIFY_AUDIO_SETTINGS is also needed for audio channel in WebRTC

BUG=https://crosswalk-project.org/jira/browse/XWALK-6069