### PR TITLE
Fix shared mode packing in extensions-android

### DIFF
--- a/extensions-android/build.sh
+++ b/extensions-android/build.sh
@@ -13,7 +13,7 @@ XWALK_VERSION="15.44.384.13"
 ARCH="x86"
 MODE="embedded"
 
-while getopts v:a:m opt
+while getopts v:a:m: opt
 do
   case "$opt" in 
   v)  XWALK_VERSION=$OPTARG;;


### PR DESCRIPTION
Lost a ":" in getopts v: a:m, it make apk always packed as embedded mode.