### PR TITLE
Update in-app-purchase to support packing via crosswalk-app-tools

### DIFF
--- a/in-app-purchase/README.md
+++ b/in-app-purchase/README.md
@@ -1,17 +1,26 @@
 ## Package for Google Play&XiaoMi Store on Android
 1. Install Crosswalk App Tools, see https://github.com/crosswalk-project/crosswalk-app-tools for details.
 2. Change ```"xwalk_package_id"``` in manifest.json to the value below:
-   * ```"com.crosswalk.iapsample"``` for Google Play.
-   * ```"com.sdk.migame.payment"``` for XiaoMi Store.
+   * ```"org.xwalk.iapdemo"``` for Google Play.
+   * ```"com.sdk.migame.payment"``` for Xiaomi Store.
 3. Download the extension zip file from https://github.com/crosswalk-project/crosswalk-android-extensions/releases and unpack it, change ```"xwalk_extensions"``` to the path of the extensions in manifest.json.
-4. Add the following additional permissions in the default AndroidManifest.xml:
+4. Add the following additional permissions to www/manifest.json:
+  For Google Play, add:
+  ```
+  "xwalk_android_permissions": [
+    "com.android.vending.BILLING"
+  ]
+  ```
 
-   ```
-   <uses-permission android:name="com.android.vending.BILLING" />
-   <uses-permission android:name="android.permission.GET_TASKS"/>
-   <uses-permission android:name="android.permission.GET_ACCOUNTS"/>
-   <uses-permission android:name="com.xiaomi.sdk.permission.PAYMENT"/>
-   ```
+  For Xiaomi Store, add
+  ```
+  "xwalk_android_permissions": [
+    "GET_TASKS",
+    "GET_ACCOUNTS",
+    "com.xiaomi.sdk.permission.PAYMENT"
+  ]
+  ```
+
 5. If you want to use XiaoMi Store, you have to embed the ```MiGameCenterSDKService.apk``` and put it under
 the ```assets``` folder of your project, please download it from http://file.market.xiaomi.com/download/Wali/03e214556fc45326e72bf816ff501eb8f3d428294/MISDKservice4.4.33.rar
 6. Run ```crosswalk-pkg```:
@@ -19,6 +28,9 @@ the ```assets``` folder of your project, please download it from http://file.mar
     crosswalk-pkg --targets="arm" --platform="android" --release \
     --crosswalk=/path/to/xwalk_app_template www/
     ```
+
+  Make sure your crosswalk-pkg is higher than 0.10.2, otherwise adding the long form permissions may fail.
+
 7. Sign the apk manually, see https://developer.android.com/tools/publishing/app-signing.html#signing-manually for details.
 
 ## Run example on iOS platform.

--- a/in-app-purchase/www/iap.html
+++ b/in-app-purchase/www/iap.html
@@ -114,9 +114,9 @@
             options.debug = true;
 
             if (channel == "Google") {
-                options.key = "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAsS5PnwtdKyYPJUe+Jr/mPtjfmIuP+fLcztR3t9ocRs4UfjsyunclopkM324NOoHGrKkkvcT+MDiP1IM2lSfH1Z39W8zMnZOZtlVSyiEitZVt39JL11A00PBn9zpBT0Zb4dm85bENFlw1B+F3K+QyDCjTJzkj/aG51NSEkXsEipyhUikgIp5HxiC63efpuH9G+Go7EThsdkDwn8yngm4KM6trtko+W/wGPYmk/LbZK2WEKpsGBOfJ3lzBf65+p8U1epd0/2Xf5qwz1dT5HiT6I7Wrh1VSRbGABOfDH4fjZVL5BVpoO9O7t9iyaBorPJbPgKXmx1aj0eG5ivNxtpNkUwIDAQAB";
+                options.key = "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA2yD8XJgCd6IPtimK6P7OenXGixfMEoK8fo5H7ravu3vVhVuEcM3f/z/3EHHGTPlCHllFsv5FcCy84iPR2AqgEDpQLRUjaf62AX799h1rthVWxeHQN2l1DzQpCVeWNiPPQLDE6zJ5Cjhr8e0hgFlxNe8iLJNssEFXZQX+xUzskNbn0CidBquIG3DLolQjJvrxxB6OizZ7BrXQ5LvVLIIQ96W2jvDd6H20NtGi88RkiXT0ayKVR7Yi1SNamu2K1OnlnEQBL/cT63hkBW0osAX1drZruMDcBHFC9SKHYynV/9dUEkUaBQ37ag0i2AEDeipdXfU7F8mUvYLEA6w1LlUuJwIDAQAB";
                 notice = noticeGoogle;
-                queryProducts = ["com.crosswalk.apple", "com.crosswalk.grape"];
+                queryProducts = ["org.xwalk.apple", "org.xwalk.orange"];
             } else if (channel == "XiaoMi") {
                 notice = noticeXiaoMi;
                 options.key = '5691723970138';

--- a/in-app-purchase/www/manifest.json
+++ b/in-app-purchase/www/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "InAppPurchaseDemo",
   "start_url": "iap.html",
-  "xwalk_package_id": "com.crosswalk.iapsample",
+  "xwalk_package_id": "org.xwalk.iapdemo",
   "xwalk_app_version": "1.0.0",
   "xwalk_extensions": ["/path/to/extensions"]
 }


### PR DESCRIPTION
Before the in-app-purchase was built via make_apk because long form permissions
(like com.android.vending.BILLING) cannot be added to crosswalk application
project via crosswalk-app-tools, but after the long form permisssions issue being
fixed, when we tried to build it via crosswalk-app-tools, it didn't work well.

Now we build a new apk via crosswalk-app-tools and upload this apk
to Google Play so this example can work well and does not depend on
the way of building apk.