### PR TITLE
[extensions-android] Update default crosswalk version to latest stable 18.48.477.13

### DIFF
--- a/extensions-android/README.md
+++ b/extensions-android/README.md
@@ -33,9 +33,9 @@ Android.
 Pre-condition:
 
   Update crosswalk version in `xwalk-echo-extension-src/build.xml` before run `build.sh`.<br />
-  e.g. change stable 15.44.384.13 to canary 18.46.452.0
+  e.g. change stable 18.48.477.13 to canary 20.50.533.0
 
-0. change `<property name="crosswalk-version" value="15.44.384.13" />` to `<property name="crosswalk-version" value="18.46.452.0" />`
+0. change `<property name="crosswalk-version" value="18.48.477.13" />` to `<property name="crosswalk-version" value="20.50.533.0" />`
 0. change `<get src="https://download.01.org/crosswalk/releases/crosswalk/android/stable/${crosswalk-version}/crosswalk-${crosswalk-version}.zip" dest="${crosswalk-zip}" />`
    to `<get src="https://download.01.org/crosswalk/releases/crosswalk/android/canary/${crosswalk-version}/crosswalk-${crosswalk-version}.zip" dest="${crosswalk-zip}" />`
 

--- a/extensions-android/build.sh
+++ b/extensions-android/build.sh
@@ -9,7 +9,7 @@ PROJECT_DIR=$(cd $(dirname $0) ; pwd)
 EXTENSION_SRC=$PROJECT_DIR/xwalk-echo-extension-src
 APP_SRC=$PROJECT_DIR/xwalk-echo-app
 
-XWALK_VERSION="15.44.384.13"
+XWALK_VERSION="18.48.477.13"
 ARCH="x86"
 MODE="embedded"
 

--- a/extensions-android/xwalk-echo-extension-src/build.xml
+++ b/extensions-android/xwalk-echo-extension-src/build.xml
@@ -7,7 +7,7 @@
   <property name="lib" value="lib" />
 
   <!-- Crosswalk Android version -->
-  <property name="crosswalk-version" value="15.44.384.13" />
+  <property name="crosswalk-version" value="18.48.477.13" />
 
   <!-- location of downloaded Crosswalk Android file -->
   <property name="crosswalk-zip" value="${lib}/crosswalk.zip" />


### PR DESCRIPTION
BUG=https://crosswalk-project.org/jira/browse/XWALK-6146
